### PR TITLE
m.neural_network.preparedata: Add option for a suffix

### DIFF
--- a/m.neural_network.preparedata/m.neural_network.preparedata.html
+++ b/m.neural_network.preparedata/m.neural_network.preparedata.html
@@ -4,6 +4,8 @@
 training data preparation of a neural network using DOPs and nDSM as input data. Additionally,
 a tile index containing information about the labeled status is created.
 
+<p>The <em>suffix</em> option may be used to add a suffix to each output tile/file in order to create unique tile IDs that can later be combined with results from other runs.</p>
+
 <h2>EXAMPLES</h2>
 
 <h3>Prepare the labeling of training data for a neural network with a tile_size of 512</h3>

--- a/m.neural_network.preparedata/m.neural_network.preparedata.py
+++ b/m.neural_network.preparedata/m.neural_network.preparedata.py
@@ -92,6 +92,15 @@
 # % guisection: Optional input
 # %end
 
+# %option
+# % key: suffix
+# % type: string
+# % required: no
+# % label: Suffix to be added to each output file
+# % description: Use the suffix to provide a unique ID for e.g. a specific flight campaign year
+# % guisection: Optional input
+# %end
+
 # %option G_OPT_M_DIR
 # % key: output_dir
 # % multiple: no
@@ -186,6 +195,8 @@ def main() -> None:
     train_percentage = int(options["train_percentage"])
     output_dir = options["output_dir"]
     nprocs = set_nprocs(int(options["nprocs"]))
+    if options["suffix"]:
+        suffix = options["suffix"]
 
     # get addon etc path
     etc_path = get_lib_path(modname="m.neural_network.preparedata")
@@ -244,6 +255,8 @@ def main() -> None:
                 col_str = str(col).zfill(num_zeros)
                 tile_id = f"{row_str}{col_str}"
                 tile_name = f"tile_{row_str}_{col_str}"
+                if options["suffix"]:
+                    tile_name += f"_{suffix}"
                 new_mapset = f"tmp_mapset_{ID}_{tile_id}"
                 rm_dirs.append(os.path.join(gisdbase, location, new_mapset))
 


### PR DESCRIPTION
This PR adds an optional option in `m.neural_network.preparedata` to add a suffix to each tile and as such each output file, e.g.:
```
tile_05_02_2020
   |-- image_tile_05_02_2020.tif
   |-- label_tile_05_02_2020.gpkg
...
```
(where 2020 is the suffix)

This allows later on to merge different outputs of `m.neural_network.preparetraining` together while avoiding file name redundancies. This can be useful to combine e.g. data from different flight campaigns in the same training step.

Adaptations to `m.neural_network.preparetraining` are not required.