### PR TITLE
m.neural_network.preparetraining: change vrts to relative paths

### DIFF
--- a/m.neural_network.preparetraining/m.neural_network.preparetraining.py
+++ b/m.neural_network.preparetraining/m.neural_network.preparetraining.py
@@ -148,9 +148,10 @@ def get_tile_infos(in_dir, ttype):
             all_tiles.append(tiledict)
     return all_tiles
 
+
 def vrt_absolute_paths(vrt, abs_paths, rel_paths):
     """
-    Changes absolute to relative paths in a .vrt
+    Change absolute to relative paths in a .vrt
     :param vrt: String: Path to the vrt
     :param abs_paths: List: absolute paths to be replaced
     :param rel_paths: List: relative paths to replace the absolute paths with
@@ -162,6 +163,7 @@ def vrt_absolute_paths(vrt, abs_paths, rel_paths):
             data = data.replace(abs_path, rel_path)
     with open(vrt, "w") as file:
         file.write(data)
+
 
 def build_vrts(outdir, dop, ndom, tile_id, singleband_vrt_dir):
     """Build the required .vrt files."""

--- a/m.neural_network.preparetraining/m.neural_network.preparetraining.py
+++ b/m.neural_network.preparetraining/m.neural_network.preparetraining.py
@@ -150,18 +150,17 @@ def get_tile_infos(in_dir, ttype):
 
 
 def vrt_absolute_paths(vrt, abs_paths, rel_paths):
-    """
-    Change absolute to relative paths in a .vrt
+    """Change absolute to relative paths in a .vrt
     :param vrt: String: Path to the vrt
     :param abs_paths: List: absolute paths to be replaced
-    :param rel_paths: List: relative paths to replace the absolute paths with
+    :param rel_paths: List: relative paths to replace the absolute paths with.
     """
     with open(vrt, "r") as file:
         data = file.read()
         data = data.replace('relativeToVRT="0"', 'relativeToVRT="1"')
         for abs_path, rel_path in zip(abs_paths, rel_paths):
             data = data.replace(abs_path, rel_path)
-    with open(vrt, "w") as file:
+    with open(vrt, "w", encoding="utf-8") as file:
         file.write(data)
 
 

--- a/m.neural_network.preparetraining/m.neural_network.preparetraining.py
+++ b/m.neural_network.preparetraining/m.neural_network.preparetraining.py
@@ -152,7 +152,7 @@ def get_tile_infos(in_dir, ttype):
 def vrt_relative_paths(vrt, abs_paths):
     """Change absolute to relative paths in a .vrt
     :param vrt: String: Path to the vrt
-    :param abs_paths: List: absolute paths to be replaced
+    :param abs_paths: List: absolute paths to be replaced.
     """
     with open(vrt, encoding="utf-8") as file:
         data = file.read()

--- a/m.neural_network.preparetraining/m.neural_network.preparetraining.py
+++ b/m.neural_network.preparetraining/m.neural_network.preparetraining.py
@@ -149,7 +149,7 @@ def get_tile_infos(in_dir, ttype):
     return all_tiles
 
 
-def vrt_absolute_paths(vrt, abs_paths, rel_paths):
+def vrt_relative_paths(vrt, abs_paths, rel_paths):
     """Change absolute to relative paths in a .vrt
     :param vrt: String: Path to the vrt
     :param abs_paths: List: absolute paths to be replaced
@@ -181,7 +181,7 @@ def build_vrts(outdir, dop, ndom, tile_id, singleband_vrt_dir):
         gdal.BuildVRT(band_vrt, [dop], options=vrt_options_sep)
         # replace absolute with relative path
         rel_path = os.path.relpath(dop, start=singleband_vrt_dir)
-        vrt_absolute_paths(band_vrt, abs_paths=[dop], rel_paths=[rel_path])
+        vrt_relative_paths(band_vrt, abs_paths=[dop], rel_paths=[rel_path])
         vrt_input.append(band_vrt)
 
     # create vrt
@@ -191,7 +191,7 @@ def build_vrts(outdir, dop, ndom, tile_id, singleband_vrt_dir):
     vrt_options = gdal.BuildVRTOptions(separate=True)
     gdal.BuildVRT(bands_e_vrt, vrt_input, options=vrt_options)
     # replace absolute with relative paths
-    vrt_absolute_paths(bands_e_vrt, abs_paths=vrt_input, rel_paths=rel_paths)
+    vrt_relative_paths(bands_e_vrt, abs_paths=vrt_input, rel_paths=rel_paths)
     return bands_e_vrt
 
 

--- a/m.neural_network.preparetraining/m.neural_network.preparetraining.py
+++ b/m.neural_network.preparetraining/m.neural_network.preparetraining.py
@@ -155,7 +155,7 @@ def vrt_absolute_paths(vrt, abs_paths, rel_paths):
     :param abs_paths: List: absolute paths to be replaced
     :param rel_paths: List: relative paths to replace the absolute paths with.
     """
-    with open(vrt, "r") as file:
+    with open(vrt, encoding="utf-8") as file:
         data = file.read()
         data = data.replace('relativeToVRT="0"', 'relativeToVRT="1"')
         for abs_path, rel_path in zip(abs_paths, rel_paths):

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,6 +8,7 @@ ignore = [
     "D205",
     "E501", # allow > 79 characters
     "F841",
+    "FURB101", # `open` and `read` should be replaced by `Path(vrt).read_text(encoding="utf-8")`
     "FURB103", # `open` and `write` should be replaced by `Path(vrt).write_text(data, encoding="utf-8")`
     "INT001",
     "PLR0912", # allow > 12 branches (if/for/else/...)

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,6 +8,7 @@ ignore = [
     "D205",
     "E501", # allow > 79 characters
     "F841",
+    "FURB103", # `open` and `write` should be replaced by `Path(vrt).write_text(data, encoding="utf-8")`
     "INT001",
     "PLR0912", # allow > 12 branches (if/for/else/...)
     "PLR0914",

--- a/ruff.toml
+++ b/ruff.toml
@@ -20,6 +20,7 @@ ignore = [
     "PTH112",
     "PTH113",
     "PTH118",
+    "PTH120", # `os.path.dirname()` should be replaced by `Path.parent`
     "PTH123",
     "PTH208",
     "S605", # using shell


### PR DESCRIPTION
This PR adapts the created .vrts such that they now contain relative paths. This allows for moving files around (if source and .vrt are moved altogether) and to have valid .vrts inside and outside of docker containers.

Unfortunately, creating relative paths in a .vrt is not part of the [gdal.BuildVrtOptions](https://gdal.org/en/stable/api/python/utilities.html#osgeo.gdal.BuildVRTOptions), so in this PR, the relative paths are hacked into the existing .vrts afterwards.