### PR TITLE
Prepare data part1: fix dop export for edge conditions

### DIFF
--- a/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
+++ b/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
@@ -240,6 +240,7 @@ def main() -> None:
         input=image_bands_group,
         output=image_file,
         type="Byte",
+        nodata=0,
         createopt=f"COMPRESS=LZW,BLOCKXSIZE={tile_size},BLOCKYSIZE={tile_size},PHOTOMETRIC=RGB,ALPHA=UNSPECIFIED",
         **EXPORT_PARAM,
     )
@@ -251,6 +252,7 @@ def main() -> None:
         input=ndsm_scaled,
         output=ndsm_sc_file,
         type="Byte",
+        nodata=0,
         createopt=f"COMPRESS=LZW,BLOCKXSIZE={tile_size},BLOCKYSIZE={tile_size}",
         **EXPORT_PARAM,
     )

--- a/m.neural_network.preparedata_part1/m.neural_network.preparedata_part1.py
+++ b/m.neural_network.preparedata_part1/m.neural_network.preparedata_part1.py
@@ -248,12 +248,14 @@ def main() -> None:
     rm_rasters.append(ndsm_scaled)
     grass.run_command("r.mapcalc", expression=ex_scale)
 
-    # Image Bands: convert to byte, if not integer or larger values than 255
+    # Image Bands:
+    # convert to byte, if not integer or values out of range [1 255]
     image_bands_new = []
     for image in image_bands:
         if (
             grass.raster_info(image)["datatype"] != "CELL"
             or grass.raster_info(image)["max"] > 255
+            or grass.raster_info(image)["min"] < 1
         ):
             image_new = f"{image.split('@')[0]}_new"
             rm_rasters.append(image_new)


### PR DESCRIPTION
* More specific condition when to clip the dop bands
* Allows giving explicit no data value of `0` for export (avoid error from `r.out.gdal`, when default no data value not fitting/used from raster)