### PR TITLE
m.neural_network.preparedata_part1: Fix errornous GISRC reading for parallel worker

### DIFF
--- a/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
+++ b/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
@@ -132,11 +132,11 @@
 # %end
 
 # %option
-# % key: new_mapset
+# % key: orig_mapset
 # % type: string
 # % required: yes
 # % multiple: no
-# % label: Name for new mapset
+# % label: Name for original mapset
 # %end
 
 # %flag
@@ -150,7 +150,6 @@ import shutil
 import grass.script as grass
 from grass.pygrass.utils import get_lib_path
 from grass.script.vector import vector_info_topo
-from grass_gis_helpers.mapset import switch_to_new_mapset
 
 # overviews,TILED=YES,BIGTIFF=YES are not needed since only tiles are exported
 EXPORT_PARAM = {
@@ -158,8 +157,6 @@ EXPORT_PARAM = {
     "flags": "mc",
     "quiet": True,
 }
-NEWGISRC = None
-GISRC = None
 ID = grass.tempname(8)
 NEW_MAPSET = None
 # pylint: disable=C0103
@@ -167,17 +164,10 @@ original_nprocs = None
 
 
 def cleanup() -> None:
-    """Clean up function switching mapsets and deleting the new one."""
-    grass.utils.try_remove(NEWGISRC)
-    os.environ["GISRC"] = GISRC
-    # delete the new mapset (doppelt haelt besser)
-    gisenv = grass.gisenv()
-    gisdbase = gisenv["GISDBASE"]
-    location = gisenv["LOCATION_NAME"]
-    mapset_dir = os.path.join(gisdbase, location, NEW_MAPSET)
-    if os.path.isdir(mapset_dir):
-        shutil.rmtree(mapset_dir)
-    """Reset nprocs"""
+    """Clean up function.
+
+    Reset nprocs
+    """
     if original_nprocs:
         grass.run_command("g.gisenv", set=f"NPROCS={original_nprocs}")
     else:
@@ -189,9 +179,9 @@ def main() -> None:
     # NOTE: avoid using r.mapcalc and similar within this exporter
     # -> only region setting and export (to reduce long runtimes for large AOIs)
 
-    global NEW_MAPSET, NEWGISRC, GISRC, original_nprocs
+    global original_nprocs
 
-    NEW_MAPSET = options["new_mapset"]
+    orig_mapset = options["orig_mapset"]
     tile_name = options["tile_name"]
     north = options["n"]
     south = options["s"]
@@ -208,9 +198,9 @@ def main() -> None:
     l_flag = flags["l"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # get addon etc path
@@ -221,9 +211,6 @@ def main() -> None:
     # make new output directory
     if not os.path.isdir(output_dir):
         os.makedirs(output_dir)
-
-    # switch to the new mapset
-    GISRC, NEWGISRC, old_mapset = switch_to_new_mapset(NEW_MAPSET, new=False)
 
     # set region
     grass.run_command(
@@ -238,13 +225,13 @@ def main() -> None:
     tile_size = grass.region()["cols"]
 
     if ndsm and "@" not in ndsm:
-        ndsm += f"@{old_mapset}"
+        ndsm += f"@{orig_mapset}"
     if ndsm_scaled and "@" not in ndsm_scaled:
-        ndsm_scaled += f"@{old_mapset}"
+        ndsm_scaled += f"@{orig_mapset}"
     if reference and "@" not in reference:
-        reference += f"@{old_mapset}"
+        reference += f"@{orig_mapset}"
     if image_bands_group and "@" not in image_bands_group:
-        image_bands_group += f"@{old_mapset}"
+        image_bands_group += f"@{orig_mapset}"
 
     # image band export
     image_file = os.path.join(output_dir, f"image_{tile_name}.tif")

--- a/m.neural_network.preparedata_part1.worker_nullcells/m.neural_network.preparedata_part1.worker_nullcells.py
+++ b/m.neural_network.preparedata_part1.worker_nullcells/m.neural_network.preparedata_part1.worker_nullcells.py
@@ -138,9 +138,9 @@ def main() -> None:
     map = options["map"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # switch to the new mapset

--- a/m.neural_network.preparedata_part1/m.neural_network.preparedata_part1.py
+++ b/m.neural_network.preparedata_part1/m.neural_network.preparedata_part1.py
@@ -132,7 +132,7 @@ from grass.pygrass.utils import get_lib_path
 from grass_gis_helpers.cleanup import general_cleanup
 from grass_gis_helpers.general import set_nprocs
 from grass_gis_helpers.mapset import verify_mapsets
-from grass_gis_helpers.parallel import check_parallel_errors
+from grass_gis_helpers.parallel import check_parallel_errors, create_grass_env
 
 # initialize global vars
 ID = grass.tempname(8)
@@ -141,10 +141,22 @@ ORIG_REGION = None
 rm_vectors = []
 rm_rasters = []
 rm_groups = []
+rm_mapsets = []
+rm_gisrcs = []
 
 
 def cleanup() -> None:
     """Clean up function calling general clean up from grass_gis_helpers."""
+    for gisrc in rm_gisrcs:
+        grass.utils.try_remove(gisrc)
+    # delete the new mapsets
+    for mapset in rm_mapsets:
+        gisenv = grass.gisenv()
+        gisdbase = gisenv["GISDBASE"]
+        location = gisenv["LOCATION_NAME"]
+        mapset_dir = os.path.join(gisdbase, location, mapset)
+        if os.path.isdir(mapset_dir):
+            shutil.rmtree(mapset_dir)
     general_cleanup(
         orig_region=ORIG_REGION,
         rm_files=rm_files,
@@ -427,6 +439,12 @@ def export_apply_tile(
     new_mapset = f"tmp_mapset_{ID}_{tile_name}"
     # update jeojson values
     tindex_gdf_ap_tiles.at[ap_tile.Index, "path"] = tile_path
+
+    rm_mapsets.append(new_mapset)
+    # Create new env with new GISRC, to avoid parallel access of same GISRC
+    orig_mapset, worker_env, worker_gisrc = create_grass_env(new_mapset)
+    rm_gisrcs.append(worker_gisrc)
+
     # worker for export
     worker_export_ap = Module(
         "m.neural_network.preparedata_part1.worker_export",
@@ -440,10 +458,12 @@ def export_apply_tile(
         ndsm=ndsm,
         ndsm_scaled=ndsm_scaled,
         output_dir=tile_path,
-        new_mapset=new_mapset,
+        orig_mapset=orig_mapset,
         run_=False,
+        env_=worker_env,
     )
     worker_export_ap.stdout_ = grass.PIPE
+    worker_export_ap.stderr_ = grass.PIPE
     return worker_export_ap
 
 
@@ -480,6 +500,11 @@ def export_training_test_tile(
     # update gdf values
     tindex_gdf_tiles.at[tile.Index, "path"] = tile_path
 
+    rm_mapsets.append(new_mapset)
+    # Create new env with new GISRC, to avoid parallel access of same GISRC
+    orig_mapset, worker_env, worker_gisrc = create_grass_env(new_mapset)
+    rm_gisrcs.append(worker_gisrc)
+
     # worker for export
     worker_export_tr = Module(
         "m.neural_network.preparedata_part1.worker_export",
@@ -496,9 +521,10 @@ def export_training_test_tile(
         segmentation_minsize=segmentation_minsize,
         segmentation_threshold=segmentation_threshold,
         output_dir=tile_path,
-        new_mapset=new_mapset,
+        orig_mapset=orig_mapset,
         flags="l" if flags["l"] else "",
         run_=False,
+        env_=worker_env,
     )
     worker_export_tr.stdout_ = grass.PIPE
     worker_export_tr.stderr_ = grass.PIPE

--- a/m.neural_network.preparedata_part2.worker_label/m.neural_network.preparedata_part2.worker_label.py
+++ b/m.neural_network.preparedata_part2.worker_label/m.neural_network.preparedata_part2.worker_label.py
@@ -144,9 +144,9 @@ def main():
     output = options["output"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # switch to the new mapset

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gdal
-grass_gis_helpers
+grass_gis_helpers>=2.6.0
 matplotlib
 ogr
 pandas


### PR DESCRIPTION
When calling `m.neural_network.preparedata_part1`, following error occured in some cases:
```
ERROR: Incomplete GRASS session: Variable 'LOCATION_NAME' not set
Traceback (most recent call last):
  File "/usr/local/grass84/scripts/m.neural_network.preparedata_part1", line 374, in main
    worker_export_ap = export_apply_tile(
                       ^^^^^^^^^^^^^^^^^^
  File "/usr/local/grass84/scripts/m.neural_network.preparedata_part1", line 434, in export_apply_tile
    worker_export_ap = Module(
                       ^^^^^^^
  File "/usr/local/grass84/etc/python/grass/pygrass/modules/interface/module.py", line 563, in __init__
    tree = fromstring(self.xml)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/xml/etree/ElementTree.py", line 1336, in XML
    return parser.close()   
           ^^^^^^^^^^^^^^   
xml.etree.ElementTree.ParseError: no element found: line 1, column 0

During handling of the above exception, another exception occurred:
```
It seems, that at some point multiple workers tries to access the same GISRC, or rather one worker modified it and the second was not able to read it. This also fits with the random occurence of the error.
(Error reprocuded within GRASS8.4 & 8.6, as well as in docker environment on VM & locally)

**Solution**:
Instead of actively switching mapset and overwriting GISRC within worker, a new environment is created for each worker beforehand, with its own GISRC and parsed to the `Module()` call of each worker.

Note: requires: https://github.com/mundialis/grass-gis-helpers/pull/61

Additional changes:
* fix type of nprocs
* improve error message parsing 