### PR TITLE
Generalize data preparation

### DIFF
--- a/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
+++ b/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
@@ -76,15 +76,15 @@
 
 # %option G_OPT_R_INPUT
 # % key: ndsm
+# % required: no
 # % label: Name of the nDSM raster
-# % answer: ndsm
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndsm_scaled
+# % required: no
 # % label: Name of the scaled nDSM raster
-# % answer: ndsm_scaled
 # % guisection: Input
 # %end
 
@@ -112,6 +112,14 @@
 # % description: Threshold = 0 merges only identical segments; threshold = 1 merges all
 # % answer: 0.3
 # % guisection: Optional input
+# %end
+
+# %option
+# % key: imagery_export_type
+# % type: string
+# % required: yes
+# % description: Export type for imagery (default: Byte)
+# % answer: Byte
 # %end
 
 # %option G_OPT_M_DIR
@@ -194,6 +202,7 @@ def main() -> None:
     reference = options["reference"]
     segmentation_minsize = int(options["segmentation_minsize"])
     segmentation_threshold = float(options["segmentation_threshold"])
+    imagery_export_type = options["imagery_export_type"]
     output_dir = options["output_dir"]
     l_flag = flags["l"]
 
@@ -239,23 +248,23 @@ def main() -> None:
         "r.out.gdal",
         input=image_bands_group,
         output=image_file,
-        type="Byte",
+        type=imagery_export_type,
         nodata=0,
         createopt=f"COMPRESS=LZW,BLOCKXSIZE={tile_size},BLOCKYSIZE={tile_size},PHOTOMETRIC=RGB,ALPHA=UNSPECIFIED",
         **EXPORT_PARAM,
     )
-
-    # scaled ndom export
-    ndsm_sc_file = os.path.join(output_dir, f"ndsm_1_255_{tile_name}.tif")
-    grass.run_command(
-        "r.out.gdal",
-        input=ndsm_scaled,
-        output=ndsm_sc_file,
-        type="Byte",
-        nodata=0,
-        createopt=f"COMPRESS=LZW,BLOCKXSIZE={tile_size},BLOCKYSIZE={tile_size}",
-        **EXPORT_PARAM,
-    )
+    if ndsm_scaled:
+        # scaled ndom export
+        ndsm_sc_file = os.path.join(output_dir, f"ndsm_1_255_{tile_name}.tif")
+        grass.run_command(
+            "r.out.gdal",
+            input=ndsm_scaled,
+            output=ndsm_sc_file,
+            type="Byte",
+            nodata=0,
+            createopt=f"COMPRESS=LZW,BLOCKXSIZE={tile_size},BLOCKYSIZE={tile_size}",
+            **EXPORT_PARAM,
+        )
 
     # segmentation or clip reference data
     if l_flag:

--- a/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
+++ b/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
@@ -119,6 +119,7 @@
 # % type: string
 # % required: yes
 # % description: Export type for imagery (default: Byte)
+# % options: Byte,Int16,UInt16,Int32,UInt32,Float32,Float64,CInt16,CInt32,CFloat32,CFloat64
 # % answer: Byte
 # %end
 

--- a/m.neural_network.preparedata_part1/m.neural_network.preparedata_part1.py
+++ b/m.neural_network.preparedata_part1/m.neural_network.preparedata_part1.py
@@ -39,7 +39,6 @@
 # % key: ndsm
 # % required: no
 # % label: Name of the nDSM raster
-# % answer: ndsm
 # % guisection: Input
 # %end
 
@@ -88,6 +87,22 @@
 # % description: Threshold = 0 merges only identical segments; threshold = 1 merges all
 # % answer: 0.3
 # % guisection: Optional input
+# %end
+
+# %option
+# % key: imagery_scale_min
+# % type: integer
+# % description: minimum scaling value for imagery
+# % required: no
+# % answer: 1
+# %end
+
+# %option
+# % key: imagery_scale_max
+# % type: integer
+# % description: maximum scaling value for imagery
+# % required: no
+# % answer: 255
 # %end
 
 # %option G_OPT_M_DIR
@@ -185,6 +200,8 @@ def main() -> None:
     reference = options["reference"]
     segmentation_minsize = int(options["segmentation_minsize"])
     segmentation_threshold = float(options["segmentation_threshold"])
+    imagery_scale_min = int(options["imagery_scale_min"])
+    imagery_scale_max = int(options["imagery_scale_max"])
     output_dir = options["output_dir"]
     nprocs = set_nprocs(int(options["nprocs"]))
 
@@ -214,10 +231,10 @@ def main() -> None:
                 )
             )
         ndsm = None
-    if ndsm == ndsm_out:
+    if ndsm_out and grass.find_file(name=ndsm_out, element="raster")["file"]:
         grass.fatal(
             _(
-                f"Parameter <ndsm_out> is set to <{ndsm}>, but the raster "
+                f"Parameter <ndsm_out> is set to <{ndsm_out}>, but the raster "
                 "map already exists!"
             )
         )
@@ -247,34 +264,38 @@ def main() -> None:
             expression=f"{ndsm} = float({dsm} - {dtm})",
         )
 
-    # nDSM scaled + export (cut to [0 30] and rescale to [1 255]))
-    ndsm_cut = "ndsm_cut"
-    ex_cut = (
-        f"{ndsm_cut} = if( {ndsm} >= 30, 30, if( {ndsm} < 0, 0, {ndsm} ) )"
-    )
-    rm_rasters.append(ndsm_cut)
-    grass.run_command("r.mapcalc", expression=ex_cut)
+    ndsm_scaled = None
+    if ndsm:
+        # nDSM scaled + export (cut to [0 30] and rescale to [1 255]))
+        ndsm_cut = "ndsm_cut"
+        ex_cut = (
+            f"{ndsm_cut} = if( {ndsm} >= 30, 30, if( {ndsm} < 0, 0, {ndsm} ) )"
+        )
+        rm_rasters.append(ndsm_cut)
+        grass.run_command("r.mapcalc", expression=ex_cut)
 
-    ndsm_scaled = "ndsm_scaled"
-    ex_scale = f"{ndsm_scaled} = int(({ndsm_cut} / 30. * 254.) + 1)"
-    rm_rasters.append(ndsm_scaled)
-    grass.run_command("r.mapcalc", expression=ex_scale)
+        ndsm_scaled = "ndsm_scaled"
+        ex_scale = f"{ndsm_scaled} = int(({ndsm_cut} / 30. * 254.) + 1)"
+        rm_rasters.append(ndsm_scaled)
+        grass.run_command("r.mapcalc", expression=ex_scale)
 
     # Image Bands:
-    # convert to byte, if not integer or values out of range [1 255]
+    # scale, if not integer
+    # or values out of range [imagery_scale_min imagery_scale_max]
+    # (default: [1 255] -> for byte + 0: no data value)
     image_bands_new = []
     for image in image_bands:
         if (
             grass.raster_info(image)["datatype"] != "CELL"
-            or grass.raster_info(image)["max"] > 255
-            or grass.raster_info(image)["min"] < 1
+            or grass.raster_info(image)["max"] > imagery_scale_max
+            or grass.raster_info(image)["min"] < imagery_scale_min
         ):
             image_new = f"{image.split('@')[0]}_new"
             rm_rasters.append(image_new)
             grass.run_command(
                 "r.mapcalc",
-                expression=f"{image_new} = int(if({image} < 1, 1, if({image} > "
-                f"255, 255, {image})))",
+                expression=f"{image_new} = int(if({image} < {imagery_scale_min}, {imagery_scale_min}, if({image} > "
+                f"{imagery_scale_max}, {imagery_scale_max}, {image})))",
             )
             image_bands_new.append(image_new)
         else:
@@ -289,6 +310,11 @@ def main() -> None:
         input=image_bands,
         quiet=True,
     )
+    # Adjust export type for imagery (default: Byte)
+    imagery_export_type = "Byte"
+    if imagery_scale_min < 1 or imagery_scale_max > 255:
+        # for now assume Int16 as sufficient for integer data
+        imagery_export_type = "Int16"
 
     # import tindex
     tindex_gdf = gpd.read_file(tindex)
@@ -321,6 +347,7 @@ def main() -> None:
                 res,
                 ndsm_scaled,
                 image_bands_group,
+                imagery_export_type,
                 tindex_gdf_tr_tiles,
                 round_decimals,
                 i,
@@ -345,6 +372,7 @@ def main() -> None:
                 res,
                 ndsm_scaled,
                 image_bands_group,
+                imagery_export_type,
                 tindex_gdf_te_tiles,
                 round_decimals,
                 i,
@@ -389,6 +417,7 @@ def main() -> None:
                 res,
                 ndsm_scaled,
                 image_bands_group,
+                imagery_export_type,
                 tindex_gdf_ap_tiles,
                 round_decimals,
                 i,
@@ -418,6 +447,7 @@ def export_apply_tile(
     res,
     ndsm_scaled,
     image_bands_group,
+    imagery_export_type,
     tindex_gdf_ap_tiles,
     round_decimals,
     i,
@@ -457,6 +487,7 @@ def export_apply_tile(
         tile_name=tile_name,
         ndsm=ndsm,
         ndsm_scaled=ndsm_scaled,
+        imagery_export_type=imagery_export_type,
         output_dir=tile_path,
         orig_mapset=orig_mapset,
         run_=False,
@@ -476,6 +507,7 @@ def export_training_test_tile(
     res,
     ndsm_scaled,
     image_bands_group,
+    imagery_export_type,
     tindex_gdf_tiles,
     round_decimals,
     i,
@@ -520,6 +552,7 @@ def export_training_test_tile(
         reference=reference,
         segmentation_minsize=segmentation_minsize,
         segmentation_threshold=segmentation_threshold,
+        imagery_export_type=imagery_export_type,
         output_dir=tile_path,
         orig_mapset=orig_mapset,
         flags="l" if flags["l"] else "",

--- a/m.neural_network.preparedata_part2/m.neural_network.preparedata_part2.py
+++ b/m.neural_network.preparedata_part2/m.neural_network.preparedata_part2.py
@@ -161,12 +161,14 @@ def get_tile_infos(in_dir, ttype):
         if os.path.isdir(tiledir) and tile.startswith("tile_"):
             tiledict["id"] = tile
             tiledict["type"] = ttype
-            tiledict["dop_tif"] = os.path.join(tiledir, f"image_{tile}.tif")
+            tiledict["imagery_tif"] = os.path.join(
+                tiledir, f"image_{tile}.tif"
+            )
             tiledict["ndom_tif"] = os.path.join(
                 tiledir,
                 f"ndsm_1_255_{tile}.tif",
             )
-            checklist = [tiledict["dop_tif"], tiledict["ndom_tif"]]
+            checklist = [tiledict["imagery_tif"], tiledict["ndom_tif"]]
             if ttype == "training":
                 tiledict["label_gpkg"] = os.path.join(
                     tiledir,
@@ -177,7 +179,16 @@ def get_tile_infos(in_dir, ttype):
             # check if they exist
             for f in checklist:
                 if not os.path.isfile(f):
-                    grass.fatal(_(f"File {f} expected but no found."))
+                    if "ndsm" in f:
+                        tiledict["ndom_tif"] = None
+                        grass.warning(
+                            _(
+                                f"File {f} not found. "
+                                "Expecting no need of ndsm."
+                            )
+                        )
+                    else:
+                        grass.fatal(_(f"File {f} expected but not found."))
 
             all_tiles.append(tiledict)
     return all_tiles
@@ -198,32 +209,43 @@ def vrt_relative_paths(vrt, abs_paths):
         file.write(data)
 
 
-def build_vrts(outdir, dop, ndom, tile_id, singleband_vrt_dir):
+def build_vrts(outdir, imagery, ndom, tile_id, singleband_vrt_dir):
     """Build the required .vrt files."""
-    src_ds = gdal.Open(dop)
-    band_count = 0
-    if src_ds is not None:
-        band_count = int(src_ds.RasterCount)
-    else:
-        grass.fatal(_(f"File {dop} is empty."))
-    src_ds = None
-
-    vrt_input = []
-    for num in range(1, band_count + 1):
-        band_vrt = os.path.join(singleband_vrt_dir, f"{tile_id}_{num}.vrt")
-        vrt_options_sep = gdal.BuildVRTOptions(bandList=[num])
-        gdal.BuildVRT(band_vrt, [dop], options=vrt_options_sep)
-        # replace absolute with relative path
-        vrt_relative_paths(band_vrt, abs_paths=[dop])
-        vrt_input.append(band_vrt)
-
-    # create vrt
-    vrt_input.append(ndom)
     bands_e_vrt = os.path.join(outdir, f"{tile_id}.vrt")
-    vrt_options = gdal.BuildVRTOptions(separate=True)
-    gdal.BuildVRT(bands_e_vrt, vrt_input, options=vrt_options)
-    # replace absolute with relative paths
-    vrt_relative_paths(bands_e_vrt, abs_paths=vrt_input)
+    if ndom:
+        # If ndom will be added: first separate imagery bands to single bands
+        # (singleband-vrts) then append ndom as additional channel (final vrts)
+        src_ds = gdal.Open(imagery)
+        band_count = 0
+        if src_ds is not None:
+            band_count = int(src_ds.RasterCount)
+        else:
+            grass.fatal(_(f"File {imagery} is empty."))
+        src_ds = None
+
+        vrt_input = []
+        for num in range(1, band_count + 1):
+            band_vrt = os.path.join(singleband_vrt_dir, f"{tile_id}_{num}.vrt")
+            vrt_options_sep = gdal.BuildVRTOptions(bandList=[num])
+            gdal.BuildVRT(band_vrt, [imagery], options=vrt_options_sep)
+            # replace absolute with relative path
+            vrt_relative_paths(band_vrt, abs_paths=[imagery])
+            vrt_input.append(band_vrt)
+
+        # create vrt
+        vrt_input.append(ndom)
+        vrt_options = gdal.BuildVRTOptions(separate=True)
+        gdal.BuildVRT(bands_e_vrt, vrt_input, options=vrt_options)
+        # replace absolute with relative paths
+        vrt_relative_paths(bands_e_vrt, abs_paths=vrt_input)
+    else:
+        # If no additional channel added to imagery,
+        # just create (final) vrt with all imagery bands
+        # (simply reference to part1-folder tif)
+        # (Note: results in empty singleband_vrts-folder)
+        gdal.BuildVRT(bands_e_vrt, imagery)
+        # replace absolute with relative paths
+        vrt_relative_paths(bands_e_vrt, abs_paths=[imagery])
     return bands_e_vrt
 
 
@@ -379,7 +401,7 @@ def main():
         tiledict["out_img_dir"] = out_img_dir
         args = [
             out_img_dir,
-            tiledict["dop_tif"],
+            tiledict["imagery_tif"],
             tiledict["ndom_tif"],
             tiledict["id"],
             singleband_vrt_dir,
@@ -415,7 +437,7 @@ def main():
                 worker = Module(
                     "m.neural_network.preparedata_part2.worker_label",
                     input=tiledict["label_gpkg"],
-                    img_path=tiledict["dop_tif"],
+                    img_path=tiledict["imagery_tif"],
                     class_values=class_values,
                     no_class_value=no_class_value,
                     class_column=class_col,


### PR DESCRIPTION
Generalize data preparation:

- Imagery band input: allow not necessarily RGBI, but also e.g. Sentinel 2 data
   - Part1:
      - DOPs are always scaled to 1 255, to ensure Byte format for export -> add options `imagery_scale_min` + `imagery_scale_max` . Keep 1 255 as default values, but allow for different max values e.g. 10.000 for S2
      - Export type of imagery data -> e.g. for Sentinel: data outside of Byte range -> use Int16
- ndom optional
  - Part1:
     - Cut and scale only if ndom given
     - Export only if ndom given
  - Part2:
     - Check if ndom files exist -> give warning if don't exist (not fatal as before, as now optional)
     - If no ndom: no single band separation of imagery needed, as nothing appended
- Additionally
   - Remove default output values  (`answer`) (e.g. `ndsm`) to ensure optional setting
   - Renamed `dop` variables to more general `imagery`