### PR TITLE
Prepare data part1: keep class number of reference (if given)

### DIFF
--- a/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
+++ b/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
@@ -290,8 +290,8 @@ def main() -> None:
                 create_seg = True
             else:
                 if (
-                    not "class_number"
-                    in grass.vector_columns("reference_clipped").keys()
+                    "class_number"
+                    not in grass.vector_columns("reference_clipped").keys()
                 ):
                     grass.run_command(
                         "v.db.addcolumn",

--- a/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
+++ b/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
@@ -291,7 +291,7 @@ def main() -> None:
             else:
                 if (
                     "class_number"
-                    not in grass.vector_columns("reference_clipped").keys()
+                    not in grass.vector_columns("reference_clipped")
                 ):
                     grass.run_command(
                         "v.db.addcolumn",

--- a/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
+++ b/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
@@ -289,9 +289,8 @@ def main() -> None:
             if vector_info_topo("reference_clipped")["centroids"] == 0:
                 create_seg = True
             else:
-                if (
-                    "class_number"
-                    not in grass.vector_columns("reference_clipped")
+                if "class_number" not in grass.vector_columns(
+                    "reference_clipped"
                 ):
                     grass.run_command(
                         "v.db.addcolumn",

--- a/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
+++ b/m.neural_network.preparedata_part1.worker_export/m.neural_network.preparedata_part1.worker_export.py
@@ -289,19 +289,23 @@ def main() -> None:
             if vector_info_topo("reference_clipped")["centroids"] == 0:
                 create_seg = True
             else:
-                grass.run_command(
-                    "v.db.addcolumn",
-                    map="reference_clipped",
-                    columns="class_number INTEGER",
-                    quiet=True,
-                )
-                grass.run_command(
-                    "v.db.update",
-                    map="reference_clipped",
-                    column="class_number",
-                    value=0,
-                    quiet=True,
-                )
+                if (
+                    not "class_number"
+                    in grass.vector_columns("reference_clipped").keys()
+                ):
+                    grass.run_command(
+                        "v.db.addcolumn",
+                        map="reference_clipped",
+                        columns="class_number INTEGER",
+                        quiet=True,
+                    )
+                    grass.run_command(
+                        "v.db.update",
+                        map="reference_clipped",
+                        column="class_number",
+                        value=0,
+                        quiet=True,
+                    )
                 grass.run_command(
                     "v.out.ogr",
                     input="reference_clipped",


### PR DESCRIPTION
Within preparation of training data, a reference/label map can be given optionally.
In this case, no segmentation is done, but these reference label are exported.
Before exporting, the needed `class_number` was always added and initalized with 0 (TODO).

If reference label already contain the column `class_number` (with the desired class values), these values should not be overwritten anymore. Instead the label should be directly exported.
If no `class_number` column given this will be added and initialized with 0, as before.